### PR TITLE
NEW: Support for Gitlab CI testing.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+# We're going to build and run a container in order to test the project. Because
+# this process will take place in a container itself, we need to use the 'Docker
+# in Docker' image, aka 'dind'.
+image: gitlab/dind
+
+stages:
+  - test
+
+# Build the image, run the container. Exposing the web service on port 3000 is
+# an arbitrary choice.
+before_script:
+  - docker info
+  - build_dir=`pwd`
+  - docker run -dP -p 3000:80 --name=recipe -v $build_dir:/var/www sminnee/silverstripe-lamp
+  - docker exec recipe composer install
+  - docker exec recipe /bin/bash framework/sake /dev/build
+
+# Run the unit tests by invoking the Makefile within the running container.
+test:
+  stage: test
+  script:
+    - docker exec recipe make test


### PR DESCRIPTION
Enable Gitlab CI support for project repositories that are hosted by Gitlab. Including this file (in combination with enabling CI Pipelines for the project) will allow automated testing to run every time a change is pushed to the repository.