### PR TITLE
MINOR: package.json no longer requires 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,9 +18,3 @@ trim_trailing_whitespace = false
 [*.yml]
 indent_size = 2
 indent_style = space
-
-[*.{yml,json}]
-# The indent size used in the `package.json` file cannot be changed
-# https://github.com/npm/npm/pull/3180#issuecomment-16336516
-indent_size = 2
-indent_style = space


### PR DESCRIPTION
Removing this link as it is an outdated/resolved issue in NPM 5.
Keeping everything 4 spaces (as far as possible) is better for a memorable rule.